### PR TITLE
Correct typo in asbtract.

### DIFF
--- a/abstract.hbs
+++ b/abstract.hbs
@@ -1,6 +1,6 @@
 <section id="abstract">
   <p>
-  This test suite demonstrates the interopability of verifiers using the VC
+  This test suite demonstrates the interoperability of verifiers using the VC
   HTTP API.
   </p>
 </section>


### PR DESCRIPTION
This is a really small PR it's just so we are sure to watch out for typos like this in the future.